### PR TITLE
Vue 2.6 lacks initialization loading code

### DIFF
--- a/demos/with-vue2.6/src/components/Player.vue
+++ b/demos/with-vue2.6/src/components/Player.vue
@@ -32,6 +32,7 @@ export default {
   },
   mounted: () => {
     console.group("mounted 组件挂载完毕状态===============》");
+    this.init();
   },
   methods: {
     init() {


### PR DESCRIPTION
When using the Vue 2.6 demo, it was found that the Player component lacks the necessary code to execute the initialization method.